### PR TITLE
Rename Maps API-key to Geocoding API key (Fix #17)

### DIFF
--- a/pretix_passbook/passbook.py
+++ b/pretix_passbook/passbook.py
@@ -1,11 +1,10 @@
 import tempfile
 from collections import OrderedDict
-
-from django.contrib.staticfiles import finders
 from typing import Tuple
 
 import pytz
 from django import forms
+from django.contrib.staticfiles import finders
 from django.core.files.storage import default_storage
 from django.template.loader import get_template
 from django.utils.translation import ugettext, ugettext_lazy as _

--- a/pretix_passbook/signals.py
+++ b/pretix_passbook/signals.py
@@ -54,7 +54,7 @@ def register_global_settings(sender, **kwargs):
             help_text=_('Optional, only necessary if the key entered above requires a password to use.')
         )),
         ('passbook_gmaps_api_key', forms.CharField(
-            label=_('Google Maps API key'),
+            label=_('Google Geocoding API key'),
             widget=forms.PasswordInput(render_value=True),
             required=False,
             help_text=_('Optional, only necessary to find coordinates automatically.')


### PR DESCRIPTION
As discussed, renaming the GMaps API-key.

However, I left the name of the setting intact, so that there is no need to rework the settings-store.