### PR TITLE
Fix event lasting more than one day being marked as expired

### DIFF
--- a/pretix_passbook/passbook.py
+++ b/pretix_passbook/passbook.py
@@ -253,7 +253,7 @@ class PassbookOutput(BaseTicketOutput):
         passfile.description = gettext('Ticket for {event} ({product})').format(event=ev.name, product=ticket)
         passfile.barcode = Barcode(message=order_position.secret, format=BarcodeFormat.QR)
         passfile.barcode.altText = order_position.secret
-        if order.event.settings.show_date_to and ev.date_to:
+        if order.event.settings.show_date_to and ev.date_to and ev.date_to.date() != ev.date_from.date():
             passfile.exprirationDate = ev.date_to.astimezone(tz).isoformat()
         else:
             passfile.relevantDate = ev.date_from.astimezone(tz).isoformat()

--- a/pretix_passbook/passbook.py
+++ b/pretix_passbook/passbook.py
@@ -253,7 +253,10 @@ class PassbookOutput(BaseTicketOutput):
         passfile.description = gettext('Ticket for {event} ({product})').format(event=ev.name, product=ticket)
         passfile.barcode = Barcode(message=order_position.secret, format=BarcodeFormat.QR)
         passfile.barcode.altText = order_position.secret
-        passfile.relevantDate = ev.date_from.astimezone(tz).isoformat()
+        if order.event.settings.show_date_to and ev.date_to:
+            passfile.exprirationDate = ev.date_to.astimezone(tz).isoformat()
+        else:
+            passfile.relevantDate = ev.date_from.astimezone(tz).isoformat()
 
         if self.event.settings.passbook_latitude and self.event.settings.passbook_longitude:
             passfile.locations = [Location(self.event.settings.passbook_latitude,

--- a/pretix_passbook/passbook.py
+++ b/pretix_passbook/passbook.py
@@ -253,10 +253,12 @@ class PassbookOutput(BaseTicketOutput):
         passfile.description = gettext('Ticket for {event} ({product})').format(event=ev.name, product=ticket)
         passfile.barcode = Barcode(message=order_position.secret, format=BarcodeFormat.QR)
         passfile.barcode.altText = order_position.secret
-        if order.event.settings.show_date_to and ev.date_to and ev.date_to.date() != ev.date_from.date():
-            passfile.exprirationDate = ev.date_to.astimezone(tz).isoformat()
+        date_from_local_time = ev.date_from.astimezone(tz)
+        date_to_local_time = ev.date_to.astimezone(tz) if ev.date_to else None
+        if order.event.settings.show_date_to and date_to_local_time and date_to_local_time.date() != date_from_local_time.date():
+            passfile.exprirationDate = date_to_local_time.isoformat()
         else:
-            passfile.relevantDate = ev.date_from.astimezone(tz).isoformat()
+            passfile.relevantDate = date_from_local_time.isoformat()
 
         if self.event.settings.passbook_latitude and self.event.settings.passbook_longitude:
             passfile.locations = [Location(self.event.settings.passbook_latitude,


### PR DESCRIPTION
Currently only relevantDate with the event’s start date is used in pkpass-files, which causes the ticket to be marked/sorted as expired when that date has passed. This is very unfortunate when an event lasts more than one day (e.g. when using season-tickets). Using expirationDate and relevantDate at the same time, does not fix this behaviour in Apple Wallet, so this PR suggests to not use relevantDate, but only expirationDate if the event has an end-date.