### PR TITLE
update the WWDRCA certificate recommendation

### DIFF
--- a/pretix_passbook/locale/ar/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/ar/LC_MESSAGES/django.po
@@ -186,8 +186,8 @@ msgstr ""
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 
 #: pretix_passbook/signals.py:45

--- a/pretix_passbook/locale/ca/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/ca/LC_MESSAGES/django.po
@@ -182,8 +182,8 @@ msgstr ""
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 
 #: pretix_passbook/signals.py:45

--- a/pretix_passbook/locale/cs/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/cs/LC_MESSAGES/django.po
@@ -185,8 +185,8 @@ msgstr ""
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 
 #: pretix_passbook/signals.py:45

--- a/pretix_passbook/locale/da/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/da/LC_MESSAGES/django.po
@@ -185,8 +185,8 @@ msgstr ""
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 
 #: pretix_passbook/signals.py:45

--- a/pretix_passbook/locale/de/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/de/LC_MESSAGES/django.po
@@ -195,11 +195,11 @@ msgstr "Passbook-CA"
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
-"Sie können das aktuelle CA-Zertifikat von Apple unter https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer herunterladen"
+"Sie können das aktuelle CA-Zertifikat von Apple unter https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer herunterladen"
 
 #: pretix_passbook/signals.py:45
 msgid "Passbook secret key"

--- a/pretix_passbook/locale/de_Informal/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/de_Informal/LC_MESSAGES/django.po
@@ -195,11 +195,11 @@ msgstr "Passbook-CA"
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
-"Du kannst das aktuelle CA-Zertifikat von Apple unter https://developer.apple."
-"com/certificationauthority/AppleWWDRCA.cer herunterladen"
+"Du kannst das aktuelle CA-Zertifikat von Apple unter https://www.apple."
+"com/certificateauthority/AppleWWDRCAG4.cer herunterladen"
 
 #: pretix_passbook/signals.py:45
 msgid "Passbook secret key"

--- a/pretix_passbook/locale/django.pot
+++ b/pretix_passbook/locale/django.pot
@@ -183,8 +183,8 @@ msgstr ""
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 
 #: pretix_passbook/signals.py:45

--- a/pretix_passbook/locale/el/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/el/LC_MESSAGES/django.po
@@ -182,8 +182,8 @@ msgstr ""
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 
 #: pretix_passbook/signals.py:45

--- a/pretix_passbook/locale/es/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/es/LC_MESSAGES/django.po
@@ -194,11 +194,11 @@ msgstr "Certificado CA para Passbook"
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
-"Puede descargar el certificado CA actual desde Apple en https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"Puede descargar el certificado CA actual desde Apple en https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 
 #: pretix_passbook/signals.py:45
 msgid "Passbook secret key"

--- a/pretix_passbook/locale/fi/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/fi/LC_MESSAGES/django.po
@@ -185,8 +185,8 @@ msgstr ""
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 
 #: pretix_passbook/signals.py:45

--- a/pretix_passbook/locale/fr/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/fr/LC_MESSAGES/django.po
@@ -185,8 +185,8 @@ msgstr ""
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 
 #: pretix_passbook/signals.py:45

--- a/pretix_passbook/locale/it/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/it/LC_MESSAGES/django.po
@@ -185,8 +185,8 @@ msgstr ""
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 
 #: pretix_passbook/signals.py:45

--- a/pretix_passbook/locale/ja/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/ja/LC_MESSAGES/django.po
@@ -182,8 +182,8 @@ msgstr ""
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 
 #: pretix_passbook/signals.py:45

--- a/pretix_passbook/locale/lv/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/lv/LC_MESSAGES/django.po
@@ -195,11 +195,11 @@ msgstr "Passbook CA Sertifikāts"
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 "Jūs varat nolādēt pašreizējo CA sertifikātu no apple šeit: "
-"https://developer.apple.com/certificationauthority/AppleWWDRCA.cer"
+"https://www.apple.com/certificateauthority/AppleWWDRCAG4.cer"
 
 #: pretix_passbook/signals.py:45
 msgid "Passbook secret key"

--- a/pretix_passbook/locale/nl/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/nl/LC_MESSAGES/django.po
@@ -196,11 +196,11 @@ msgstr "Passbook CA-certificaat"
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
-"U kunt het huidige CA-certificaat van Apple downloaden via https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"U kunt het huidige CA-certificaat van Apple downloaden via https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 
 #: pretix_passbook/signals.py:45
 msgid "Passbook secret key"

--- a/pretix_passbook/locale/nl_BE/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/nl_BE/LC_MESSAGES/django.po
@@ -182,8 +182,8 @@ msgstr ""
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 
 #: pretix_passbook/signals.py:45

--- a/pretix_passbook/locale/nl_Informal/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/nl_Informal/LC_MESSAGES/django.po
@@ -196,11 +196,11 @@ msgstr "Passbook CA-certificaat"
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
-"Je kan het huidige CA-certificaat van Apple downloaden via https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"Je kan het huidige CA-certificaat van Apple downloaden via https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 
 #: pretix_passbook/signals.py:45
 msgid "Passbook secret key"

--- a/pretix_passbook/locale/pl/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/pl/LC_MESSAGES/django.po
@@ -194,11 +194,11 @@ msgstr "Certyfikat CA passbooka"
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
-"Najnowsze CA możliwe do pobrania od Apple na https://developer.apple.com/"
-"certificationauthority/AppleWWDRCA.cer"
+"Najnowsze CA możliwe do pobrania od Apple na https://www.apple.com/"
+"certificateauthority/AppleWWDRCAG4.cer"
 
 #: pretix_passbook/signals.py:45
 msgid "Passbook secret key"

--- a/pretix_passbook/locale/pl_Informal/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/pl_Informal/LC_MESSAGES/django.po
@@ -182,8 +182,8 @@ msgstr ""
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 
 #: pretix_passbook/signals.py:45

--- a/pretix_passbook/locale/pt/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/pt/LC_MESSAGES/django.po
@@ -182,8 +182,8 @@ msgstr ""
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 
 #: pretix_passbook/signals.py:45

--- a/pretix_passbook/locale/pt_BR/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/pt_BR/LC_MESSAGES/django.po
@@ -185,8 +185,8 @@ msgstr ""
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 
 #: pretix_passbook/signals.py:45

--- a/pretix_passbook/locale/ro/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/ro/LC_MESSAGES/django.po
@@ -182,8 +182,8 @@ msgstr ""
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 
 #: pretix_passbook/signals.py:45

--- a/pretix_passbook/locale/ru/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/ru/LC_MESSAGES/django.po
@@ -196,11 +196,11 @@ msgstr "Сертификат ЦС Passbook"
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 "Вы можете скачать текущий сертификат ЦС Apple по адресу "
-"https://developer.apple.com/certificationauthority/AppleWWDRCA.cer."
+"https://www.apple.com/certificateauthority/AppleWWDRCAG4.cer."
 
 #: pretix_passbook/signals.py:45
 msgid "Passbook secret key"

--- a/pretix_passbook/locale/si/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/si/LC_MESSAGES/django.po
@@ -185,8 +185,8 @@ msgstr ""
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 
 #: pretix_passbook/signals.py:45

--- a/pretix_passbook/locale/sl/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/sl/LC_MESSAGES/django.po
@@ -182,8 +182,8 @@ msgstr ""
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 
 #: pretix_passbook/signals.py:45

--- a/pretix_passbook/locale/sv/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/sv/LC_MESSAGES/django.po
@@ -185,8 +185,8 @@ msgstr ""
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 
 #: pretix_passbook/signals.py:45

--- a/pretix_passbook/locale/tr/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/tr/LC_MESSAGES/django.po
@@ -196,11 +196,11 @@ msgstr "Hesap Cüzdanı CA Sertifikası"
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
-"Geçerli CA sertifikasını apple'dan https://developer.apple.com/"
-"certificationauthority/AppleWWDRCA.cer adresinden indirebilirsiniz."
+"Geçerli CA sertifikasını apple'dan https://www.apple.com/"
+"certificateauthority/AppleWWDRCAG4.cer adresinden indirebilirsiniz."
 
 #: pretix_passbook/signals.py:45
 msgid "Passbook secret key"

--- a/pretix_passbook/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/pretix_passbook/locale/zh_Hans/LC_MESSAGES/django.po
@@ -185,8 +185,8 @@ msgstr ""
 
 #: pretix_passbook/signals.py:40
 msgid ""
-"You can download the current CA certificate from apple at https://developer."
-"apple.com/certificationauthority/AppleWWDRCA.cer"
+"You can download the current CA certificate from apple at https://www."
+"apple.com/certificateauthority/AppleWWDRCAG4.cer"
 msgstr ""
 
 #: pretix_passbook/signals.py:45

--- a/pretix_passbook/signals.py
+++ b/pretix_passbook/signals.py
@@ -38,7 +38,7 @@ def register_global_settings(sender, **kwargs):
         ('passbook_wwdr_certificate_file', CertificateFileField(
             label=_('Passbook CA Certificate'),
             help_text=_('You can download the current CA certificate from apple at '
-                        'https://developer.apple.com/certificationauthority/AppleWWDRCA.cer'),
+                        'https://www.apple.com/certificateauthority/AppleWWDRCAG4.cer'),
             required=False,
         )),
         ('passbook_key', forms.CharField(


### PR DESCRIPTION
Currently the plugin recommends downloading `https://apple.com/certificationauthority/AppleWWDRCA.cer`, which is set to expire on Feb. 7, 2023, 9:48 p.m. (only 4ish months from now). 

This updates the recommendation to download `https://apple.com/certificationauthority/AppleWWDRCAG4.cer`, which replaced this certificate (per https://developer.apple.com/news/?id=5zb13auf). 

This PR does **_not_** include code to check whether the Apple WWDRCA has expired, nor that it is set to expire soon. It simply updates the translations. 