### PR TITLE
fix: display name independent from the seat

### DIFF
--- a/pretix_passbook/passbook.py
+++ b/pretix_passbook/passbook.py
@@ -326,7 +326,8 @@ class PassbookOutput(BaseTicketOutput):
                 card.addAuxiliaryField(
                     "seat", gettext("General admission"), gettext("Seat")
                 )
-        elif order_position.attendee_name:
+
+        if order_position.attendee_name:
             card.addAuxiliaryField(
                 "name", order_position.attendee_name, gettext("Attendee name")
             )


### PR DESCRIPTION
I stumbled across a "bug" that makes the attendee name disappear when they have a seat linked to their ticket. In my opinion the name should still be displayed on the Wallet ticket even if the attendee has a seat assigned to themselves. 

I'm wondering if this behaviour is wanted or not. The elif makes the name disappear if the order position has a seat linked. See:

https://github.com/pretix/pretix-passbook/blob/a9eacfc344576a40fd5183dd77f8fc7d0cd39acf/pretix_passbook/passbook.py#L321-L332