### PR TITLE
Fix #46 - Improved Validation of RSA Private Key

### DIFF
--- a/pretix_passbook/forms.py
+++ b/pretix_passbook/forms.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import subprocess
 import tempfile
 from django import forms
@@ -15,12 +16,10 @@ def validate_rsa_privkey(value: str):
     value = value.strip()
     if not value:
         return
-    if not value.startswith("-----BEGIN RSA PRIVATE KEY-----") or not value.endswith(
-        "-----END RSA PRIVATE KEY-----"
-    ):
+    if not re.match(r"^-----BEGIN( (RSA |ENCRYPTED )?PRIVATE KEY-----).*-----END\1$", value, re.DOTALL):
         raise ValidationError(
             _(
-                "This does not look like a RSA private key in PEM format (it misses the begin or end signifiers)"
+                "This does not look like an RSA private key in PEM format (it misses the correct begin or end signifiers)"
             ),
         )
 


### PR DESCRIPTION
RSA Private Keys cannot only be stored in PKCS '#1' format but also in the more generic PKCS '#8' format.  According to [RFC 7468 PKIX Textual Encodings](https://www.rfc-editor.org/rfc/rfc7468) (Chapter 10/11) the Textual Encoding of Private Keys in PKCS '#8' in PEM format use the ``PRIVATE KEY`` label and Encrypted Private Keys use the ``ENCRYPTED PRIVATE KEY`` label.
So the PEM format starts/ends not only with 
```
-----BEGIN RSA PRIVATE KEY-----
...
-----END RSA PRIVATE KEY-----
```
but can also use the aforementioned labels.