### PR TITLE
Rename "Passbook" into "Apple Wallet"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Development setup
 
 
 Obtaining *Pass Type ID certificates* and configuring them in pretix
-------------------------------------------------------------------
+--------------------------------------------------------------------
 
 1. To obtain a *Pass Type ID certificate* you need to generate an *RSA private key* and a certificate signing request (CSR) using::
 
@@ -57,7 +57,7 @@ Obtaining *Pass Type ID certificates* and configuring them in pretix
     - Add the Pass Type ID  
       (The Pass Type ID is your identifier, for example ``pass.pretix.example``)
     - Upload the *Pass Type ID certificate* (``pass-pretix.pem``)
-    - Add the right *Apple Intermediate Certificate* for your certificate to *Passbook CA of Apple*  
+    - Add the right *Apple Intermediate Certificate* for your certificate 
       (You can download the current certificate from Apple at https://www.apple.com/certificateauthority/AppleWWDRCAG4.cer)
     - Paste the *RSA private key* (``pass-pretix.key``) into the secret key field
     - If you have configured your *RSA private key* with a password, it is necessary to provide it in pretix
@@ -77,4 +77,3 @@ Released under the terms of the Apache License 2.0
 .. _pretix: https://github.com/pretix/pretix
 .. _Code of Conduct: https://docs.pretix.eu/en/latest/development/contribution/codeofconduct.html
 .. _pretix development setup: https://docs.pretix.eu/en/latest/development/setup.html
-

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ pretix-passbook
 .. image:: https://travis-ci.org/pretix/pretix-passbook.svg?branch=master
    :target: https://travis-ci.org/pretix/pretix-passbook
 
-This is a plugin for `pretix`_. It allows to provide tickets in the passbook format supported by Apple Wallet and a
+This is a plugin for `pretix`_. It allows to provide tickets in the pkpass format supported by Apple Wallet and a
 number of Android apps.
 
 Contributing
@@ -36,26 +36,33 @@ Development setup
    the 'plugins' tab in the settings.
 
 
-Generating Passbook keys and configuring them in pretix
--------------------------------------------------------
+Obtaining Pass Type ID certificates and configuring them in pretix
+------------------------------------------------------------------
 
-You can generate a key and CSR using::
+1. To obtain a *Pass Type ID certificate* you need to generate an RSA private key and a certificate signing request (CSR) using::
 
     export CERT_NAME=pass-pretix
-    openssl genrsa -out $CERT_NAME.key 2048
-    openssl pkey -in $CERT_NAME.key -traditional > $CERT_NAME.key.pem
+    openssl genpkey -out $CERT_NAME.key -algorithm RSA -pkeyopt rsa_keygen_bits:2048
     openssl req -new -key $CERT_NAME.key -out $CERT_NAME.csr
 
-You can then request a certificate using that CSR in your `Apple developer account`_. You can then convert the downloaded certificate like this::
+2. Request a *Pass Type ID certificate* using this CSR in your `Apple developer account`_ and download the certificate (as pass-pretix.cer)
+
+3. Convert the downloaded certificate to PEM format::
 
     openssl x509 -inform der -in $CERT_NAME.cer -out $CERT_NAME.pem
     
-After generating the .pem file, upload it to pretix as passbook certificate.
-Make sure you have uploaded the key generated before (pass-pretix.key) and added the passbook CA of apple.
-Next add your Team ID in pretix and the passbook type id. The passbook type id is your identifier, as example pass.pretix.example. The Team ID can be found under "Organizational Unit" when opening the passbook certificate, e.g. with Keychain on MacOS.  
-If you have configured your private rsa key with a password you can provide it in pretix.
+4. Setup your *Pass Type ID certificate* in pretix within global settings
+    - Add your Team ID  
+      (The Team ID can be found under "Organizational Unit" when opening the passbook certificate, e.g. with Keychain on MacOS or you can find it in your `Apple developer account`_)
+    - Add the Pass Type ID  
+      (The Pass Type ID is your identifier, for example pass.pretix.example)
+    - Upload the *Pass Type ID certificate* (pass-pretix.pem)
+    - Add the right *Apple Intermediate Certificate* for your certificate to *Passbook CA of Apple*  
+      (You can download the current certificate from Apple at https://www.apple.com/certificateauthority/AppleWWDRCAG4.cer)
+    - Paste the *RSA private key* (pass-pretix.key) into the secret key field
+    - If you have configured your RSA private key with a password, it is necessary to provide it in pretix
+    - Click on `Save`
 
-Click on Save.
 Enjoy!
 
 License
@@ -70,3 +77,4 @@ Released under the terms of the Apache License 2.0
 .. _pretix: https://github.com/pretix/pretix
 .. _Code of Conduct: https://docs.pretix.eu/en/latest/development/contribution/codeofconduct.html
 .. _pretix development setup: https://docs.pretix.eu/en/latest/development/setup.html
+

--- a/README.rst
+++ b/README.rst
@@ -36,16 +36,16 @@ Development setup
    the 'plugins' tab in the settings.
 
 
-Obtaining Pass Type ID certificates and configuring them in pretix
+Obtaining *Pass Type ID certificates* and configuring them in pretix
 ------------------------------------------------------------------
 
-1. To obtain a *Pass Type ID certificate* you need to generate an RSA private key and a certificate signing request (CSR) using::
+1. To obtain a *Pass Type ID certificate* you need to generate an *RSA private key* and a certificate signing request (CSR) using::
 
     export CERT_NAME=pass-pretix
     openssl genpkey -out $CERT_NAME.key -algorithm RSA -pkeyopt rsa_keygen_bits:2048
     openssl req -new -key $CERT_NAME.key -out $CERT_NAME.csr
 
-2. Request a *Pass Type ID certificate* using this CSR in your `Apple developer account`_ and download the certificate (as pass-pretix.cer)
+2. Request a *Pass Type ID certificate* using the CSR (``pass-pretix.csr``) in your `Apple developer account`_ and download the certificate (as ``pass-pretix.cer``)
 
 3. Convert the downloaded certificate to PEM format::
 
@@ -53,14 +53,14 @@ Obtaining Pass Type ID certificates and configuring them in pretix
     
 4. Setup your *Pass Type ID certificate* in pretix within global settings
     - Add your Team ID  
-      (The Team ID can be found under "Organizational Unit" when opening the passbook certificate, e.g. with Keychain on MacOS or you can find it in your `Apple developer account`_)
+      (The Team ID can be found under "Organizational Unit" when opening the certificate, e.g. with Keychain on MacOS or you can find it in your `Apple developer account`_)
     - Add the Pass Type ID  
-      (The Pass Type ID is your identifier, for example pass.pretix.example)
-    - Upload the *Pass Type ID certificate* (pass-pretix.pem)
+      (The Pass Type ID is your identifier, for example ``pass.pretix.example``)
+    - Upload the *Pass Type ID certificate* (``pass-pretix.pem``)
     - Add the right *Apple Intermediate Certificate* for your certificate to *Passbook CA of Apple*  
       (You can download the current certificate from Apple at https://www.apple.com/certificateauthority/AppleWWDRCAG4.cer)
-    - Paste the *RSA private key* (pass-pretix.key) into the secret key field
-    - If you have configured your RSA private key with a password, it is necessary to provide it in pretix
+    - Paste the *RSA private key* (``pass-pretix.key``) into the secret key field
+    - If you have configured your *RSA private key* with a password, it is necessary to provide it in pretix
     - Click on `Save`
 
 Enjoy!

--- a/pretix_passbook/apps.py
+++ b/pretix_passbook/apps.py
@@ -7,12 +7,12 @@ from . import __version__
 
 class PassbookApp(AppConfig):
     name = "pretix_passbook"
-    verbose_name = "Passbook Tickets"
+    verbose_name = "Apple Wallet Tickets"
 
     class PretixPluginMeta:
         name = gettext_lazy("Passbook Tickets")
         author = "Tobias Kunze, Raphael Michel"
-        description = gettext_lazy("Provides passbook tickets for pretix")
+        description = gettext_lazy("Provides Apple Wallet tickets for pretix")
         category = "FORMAT"
         visible = True
         featured = True

--- a/pretix_passbook/signals.py
+++ b/pretix_passbook/signals.py
@@ -23,30 +23,38 @@ def register_global_settings(sender, **kwargs):
             (
                 "passbook_team_id",
                 forms.CharField(
-                    label=_("Passbook team ID"),
+                    label=_("Passbook: Team ID"),
+                    help_text=_(
+                        "The Team ID can be found under 'Organizational Unit' when "
+                        "opening the certificate, e.g. with Keychain on MacOS or you "
+                        "can find it in your Apple developer account"
+                    ),
                     required=False,
                 ),
             ),
             (
                 "passbook_pass_type_id",
                 forms.CharField(
-                    label=_("Passbook type"),
+                    label=_("Passbook: Pass Type ID"),
+                    help_text=_(
+                        "The Pass Type ID is your identifier, for example pass.pretix.example"
+                    ),
                     required=False,
                 ),
             ),
             (
                 "passbook_certificate_file",
                 CertificateFileField(
-                    label=_("Passbook certificate file"),
+                    label=_("Passbook: Pass Type ID Certificate"),
                     required=False,
                 ),
             ),
             (
                 "passbook_wwdr_certificate_file",
                 CertificateFileField(
-                    label=_("Passbook CA Certificate"),
+                    label=_("Passbook: Apple Intermediate Certificate"),
                     help_text=_(
-                        "You can download the current CA certificate from apple at "
+                        "You can download the current certificate from Apple at "
                         "https://www.apple.com/certificateauthority/AppleWWDRCAG4.cer"
                     ),
                     required=False,
@@ -55,7 +63,7 @@ def register_global_settings(sender, **kwargs):
             (
                 "passbook_key",
                 forms.CharField(
-                    label=_("Passbook secret key"),
+                    label=_("Passbook: RSA private key"),
                     required=False,
                     widget=forms.Textarea,
                     validators=[validate_rsa_privkey],
@@ -64,11 +72,11 @@ def register_global_settings(sender, **kwargs):
             (
                 "passbook_key_password",
                 forms.CharField(
-                    label=_("Passbook key password"),
+                    label=_("Passbook: RSA private key password"),
                     widget=forms.PasswordInput(render_value=True),
                     required=False,
                     help_text=_(
-                        "Optional, only necessary if the key entered above requires a password to use."
+                        "Optional, only necessary if the RSA private key entered above requires a password."
                     ),
                 ),
             ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pretix-passbook"
 dynamic = ["version"]
-description = "Passbook tickets for pretix"
+description = "Apple Wallet tickets for pretix"
 readme = "README.rst"
 requires-python = ">=3.9"
 license = {file = "LICENSE"}


### PR DESCRIPTION
Already 2015, "Apple Passbook" was renamed "Apple Wallet" with the release of iOS 9. Several labels have been renamed to reflect that change and to use the terminology of Apple for the "Pass Type ID certificate".
Moreover, according to the man page, the ``openssl genrsa`` command is superseded by ``genpkey`` for the generation of RSA Private Keys. 
The README.rst file has been adjusted to reflect these changes.